### PR TITLE
Implementation of SAC

### DIFF
--- a/coax/policy_objectives/_soft_pg.py
+++ b/coax/policy_objectives/_soft_pg.py
@@ -29,6 +29,10 @@ from ._deterministic_pg import DeterministicPG
 class SoftPG(DeterministicPG):
 
     def objective_func(self, params, state, hyperparams, rng, transition_batch, Adv):
+        """
+        This does almost the same as `DeterministicPG.objective_func` except that
+        the action for the state is sampled instead of taking the mode.
+        """
         rngs = hk.PRNGSequence(rng)
 
         # get distribution params from function approximator

--- a/coax/policy_objectives/_soft_pg.py
+++ b/coax/policy_objectives/_soft_pg.py
@@ -19,47 +19,35 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.          #
 # ------------------------------------------------------------------------------------------------ #
 
-r"""
-Policy Objectives
-=================
+import jax.numpy as jnp
+import haiku as hk
+import chex
 
-.. autosummary::
-    :nosignatures:
-
-    coax.policy_objectives.VanillaPG
-    coax.policy_objectives.PPOClip
-    coax.policy_objectives.DeterministicPG
-    coax.policy_objectives.SoftPG
-
-
-----
-
-This is a collection of policy objectives that can be used in policy-gradient
-methods.
-
-
-Object Reference
-----------------
-
-.. autoclass:: coax.policy_objectives.VanillaPG
-.. autoclass:: coax.policy_objectives.PPOClip
-.. autoclass:: coax.policy_objectives.DeterministicPG
-.. autoclass:: coax.policy_objectives.SoftPG
-
-"""
-
-from ._base import PolicyObjective
-from ._vanilla_pg import VanillaPG
-from ._ppo_clip import PPOClip
 from ._deterministic_pg import DeterministicPG
-from ._soft_pg import SoftPG
 
 
-__all__ = (
-    'PolicyObjective',
-    'VanillaPG',
-    # 'CrossEntropy',  # TODO
-    'PPOClip',
-    'DeterministicPG',
-    'SoftPG'
-)
+class SoftPG(DeterministicPG):
+
+    def objective_func(self, params, state, hyperparams, rng, transition_batch, Adv):
+        rngs = hk.PRNGSequence(rng)
+
+        # get distribution params from function approximator
+        S = self.pi.observation_preprocessor(next(rngs), transition_batch.S)
+        dist_params, state_new = self.pi.function(params, state, next(rngs), S, True)
+        A = self.pi.proba_dist.sample(dist_params, next(rngs))
+        log_pi = self.pi.proba_dist.log_proba(dist_params, A)
+
+        # compute objective: q(s, a)
+        S = self.q_targ.observation_preprocessor(next(rngs), transition_batch.S)
+        params_q, state_q = hyperparams['q']['params'], hyperparams['q']['function_state']
+        Q, _ = self.q_targ.function_type1(params_q, state_q, next(rngs), S, A, True)
+
+        # clip importance weights to reduce variance
+        W = jnp.clip(transition_batch.W, 0.1, 10.)
+
+        # the objective
+        chex.assert_equal_shape([W, Q])
+        chex.assert_rank([W, Q], 1)
+        objective = W * Q
+
+        return jnp.mean(objective), (dist_params, log_pi, state_new)

--- a/coax/td_learning/__init__.py
+++ b/coax/td_learning/__init__.py
@@ -33,6 +33,7 @@ TD Learning
     coax.td_learning.DoubleQLearning
     coax.td_learning.SoftQLearning
     coax.td_learning.ClippedDoubleQLearning
+    coax.td_learning.SoftClippedDoubleQLearning
 
 ----
 
@@ -52,6 +53,7 @@ Object Reference
 .. autoclass:: coax.td_learning.DoubleQLearning
 .. autoclass:: coax.td_learning.SoftQLearning
 .. autoclass:: coax.td_learning.ClippedDoubleQLearning
+.. autoclass:: coax.td_learning.SoftClippedDoubleQLearning
 
 
 """
@@ -63,6 +65,7 @@ from ._qlearning import QLearning
 from ._doubleqlearning import DoubleQLearning
 from ._softqlearning import SoftQLearning
 from ._clippeddoubleqlearning import ClippedDoubleQLearning
+from ._softclippeddoubleqlearning import SoftClippedDoubleQLearning
 
 
 __all__ = (
@@ -72,5 +75,6 @@ __all__ = (
     'QLearning',
     'DoubleQLearning',
     'SoftQLearning',
-    'ClippedDoubleQLearning'
+    'ClippedDoubleQLearning',
+    'SoftClippedDoubleQLearning'
 )

--- a/coax/td_learning/_softclippeddoubleqlearning.py
+++ b/coax/td_learning/_softclippeddoubleqlearning.py
@@ -29,6 +29,10 @@ from ._clippeddoubleqlearning import ClippedDoubleQLearning
 class SoftClippedDoubleQLearning(ClippedDoubleQLearning):
 
     def target_func(self, target_params, target_state, rng, transition_batch):
+        """
+        This does almost the same as `ClippedDoubleQLearning.target_func` except that
+        the action for the next state is sampled instead of taking the mode.
+        """
         rngs = hk.PRNGSequence(rng)
 
         # collect list of q-values

--- a/coax/td_learning/_softclippeddoubleqlearning.py
+++ b/coax/td_learning/_softclippeddoubleqlearning.py
@@ -1,0 +1,83 @@
+# ------------------------------------------------------------------------------------------------ #
+# MIT License                                                                                      #
+#                                                                                                  #
+# Copyright (c) 2020, Microsoft Corporation                                                        #
+#                                                                                                  #
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software    #
+# and associated documentation files (the "Software"), to deal in the Software without             #
+# restriction, including without limitation the rights to use, copy, modify, merge, publish,       #
+# distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the    #
+# Software is furnished to do so, subject to the following conditions:                             #
+#                                                                                                  #
+# The above copyright notice and this permission notice shall be included in all copies or         #
+# substantial portions of the Software.                                                            #
+#                                                                                                  #
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING    #
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND       #
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,     #
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   #
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.          #
+# ------------------------------------------------------------------------------------------------ #
+
+import jax.numpy as jnp
+import haiku as hk
+from gym.spaces import Discrete
+
+from ._clippeddoubleqlearning import ClippedDoubleQLearning
+
+
+class SoftClippedDoubleQLearning(ClippedDoubleQLearning):
+
+    def target_func(self, target_params, target_state, rng, transition_batch):
+        rngs = hk.PRNGSequence(rng)
+
+        # collect list of q-values
+        if isinstance(self.q.action_space, Discrete):
+            Q_sa_next_list = []
+            qs = list(zip(self.q_targ_list, target_params['q_targ'], target_state['q_targ']))
+
+            # compute A_next from q_i
+            for q_i, params_i, state_i in qs:
+                S_next = q_i.observation_preprocessor(next(rngs), transition_batch.S_next)
+                Q_s_next, _ = q_i.function_type2(params_i, state_i, next(rngs), S_next, False)
+                assert Q_s_next.ndim == 2, f"bad shape: {Q_s_next.shape}"
+                A_next = (Q_s_next == Q_s_next.max(axis=1, keepdims=True)).astype(Q_s_next.dtype)
+                A_next /= A_next.sum(axis=1, keepdims=True)  # there may be ties
+
+                # evaluate on q_j
+                for q_j, params_j, state_j in qs:
+                    S_next = q_j.observation_preprocessor(next(rngs), transition_batch.S_next)
+                    Q_sa_next, _ = q_j.function_type1(
+                        params_j, state_j, next(rngs), S_next, A_next, False)
+                    assert Q_sa_next.ndim == 1, f"bad shape: {Q_sa_next.shape}"
+                    f_inv = q_j.value_transform.inverse_func
+                    Q_sa_next_list.append(f_inv(Q_sa_next))
+
+        else:
+            Q_sa_next_list = []
+            qs = list(zip(self.q_targ_list, target_params['q_targ'], target_state['q_targ']))
+            pis = list(zip(self.pi_targ_list, target_params['pi_targ'], target_state['pi_targ']))
+
+            # compute A_next from pi_i
+            for pi_i, params_i, state_i in pis:
+                S_next = pi_i.observation_preprocessor(next(rngs), transition_batch.S_next)
+                dist_params, _ = pi_i.function(params_i, state_i, next(rngs), S_next, False)
+                A_next = pi_i.proba_dist.sample(dist_params, next(rngs))
+
+                # evaluate on q_j
+                for q_j, params_j, state_j in qs:
+                    S_next = q_j.observation_preprocessor(next(rngs), transition_batch.S_next)
+                    Q_sa_next, _ = q_j.function_type1(
+                        params_j, state_j, next(rngs), S_next, A_next, False)
+                    assert Q_sa_next.ndim == 1, f"bad shape: {Q_sa_next.shape}"
+                    f_inv = q_j.value_transform.inverse_func
+                    Q_sa_next_list.append(f_inv(Q_sa_next))
+
+        # take the min to mitigate over-estimation
+        Q_sa_next_list = jnp.stack(Q_sa_next_list, axis=-1)
+        assert Q_sa_next_list.ndim == 2, f"bad shape: {Q_sa_next_list.shape}"
+        Q_sa_next = jnp.min(Q_sa_next_list, axis=-1)
+
+        assert Q_sa_next.ndim == 1, f"bad shape: {Q_sa_next.shape}"
+        f = self.q.value_transform.transform_func
+        return f(transition_batch.Rn + transition_batch.In * Q_sa_next)

--- a/doc/examples/pendulum/sac.py
+++ b/doc/examples/pendulum/sac.py
@@ -1,0 +1,111 @@
+import gym
+import jax
+import coax
+import haiku as hk
+import jax.numpy as jnp
+from numpy import prod
+import optax
+
+
+# the name of this script
+name = 'sac'
+
+# the Pendulum MDP
+env = gym.make('Pendulum-v1')
+env = coax.wrappers.TrainMonitor(env, name=name, tensorboard_dir=f"./data/tensorboard/{name}")
+
+
+def func_pi(S, is_training):
+    seq = hk.Sequential((
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(2 * prod(env.action_space.shape), w_init=jnp.zeros),
+        hk.Reshape((2, *env.action_space.shape)),
+    ))
+    x = seq(S)
+    mu, logvar = x[:, 0], x[:, 1]
+    return {'mu': mu, 'logvar': logvar}
+
+
+def func_q(S, A, is_training):
+    seq = hk.Sequential((
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(8), jax.nn.relu,
+        hk.Linear(1, w_init=jnp.zeros), jnp.ravel
+    ))
+    X = jnp.concatenate((S, A), axis=-1)
+    return seq(X)
+
+
+# main function approximators
+pi = coax.Policy(func_pi, env)
+q1 = coax.Q(func_q, env, action_preprocessor=pi.proba_dist.preprocess_variate)
+q2 = coax.Q(func_q, env, action_preprocessor=pi.proba_dist.preprocess_variate)
+
+
+# target network
+q1_targ = q1.copy()
+q2_targ = q2.copy()
+
+# experience tracer
+tracer = coax.reward_tracing.NStep(n=5, gamma=0.9)
+buffer = coax.experience_replay.SimpleReplayBuffer(capacity=25000)
+
+
+# updaters (use current pi to update the q-functions and use sampled action in contrast to TD3)
+qlearning1 = coax.td_learning.SoftClippedDoubleQLearning(
+    q1, pi_targ_list=[pi], q_targ_list=[q1_targ, q2_targ],
+    loss_function=coax.value_losses.mse, optimizer=optax.adam(1e-3))
+qlearning2 = coax.td_learning.SoftClippedDoubleQLearning(
+    q2, pi_targ_list=[pi], q_targ_list=[q1_targ, q2_targ],
+    loss_function=coax.value_losses.mse, optimizer=optax.adam(1e-3))
+soft_pg = coax.policy_objectives.SoftPG(pi, q1_targ, optimizer=optax.adam(
+    1e-3), regularizer=coax.regularizers.EntropyRegularizer(pi, beta=0.2))
+
+
+# train
+while env.T < 1000000:
+    s = env.reset()
+
+    for t in range(env.spec.max_episode_steps):
+        a = pi(s)
+        s_next, r, done, info = env.step(a)
+
+        # trace rewards and add transition to replay buffer
+        tracer.add(s, a, r, done)
+        while tracer:
+            buffer.add(tracer.pop())
+
+        # learn
+        if len(buffer) >= 5000:
+            transition_batch = buffer.sample(batch_size=128)
+
+            # init metrics dict
+            metrics = {}
+
+            # flip a coin to decide which of the q-functions to update
+            qlearning = qlearning1 if jax.random.bernoulli(q1.rng) else qlearning2
+            metrics.update(qlearning.update(transition_batch))
+
+            # delayed policy updates
+            if env.T >= 7500 and env.T % 4 == 0:
+                metrics.update(soft_pg.update(transition_batch))
+
+            env.record_metrics(metrics)
+
+            # sync target networks
+            q1_targ.soft_update(q1, tau=0.001)
+            q2_targ.soft_update(q2, tau=0.001)
+
+        if done:
+            break
+
+        s = s_next
+
+    # generate an animated GIF to see what's going on
+    if env.period(name='generate_gif', T_period=10000) and env.T > 5000:
+        T = env.T - env.T % 10000  # round to 10000s
+        coax.utils.generate_gif(
+            env=env, policy=pi, filepath=f"./data/gifs/{name}/T{T:08d}.gif")

--- a/doc/examples/pendulum/sac.rst
+++ b/doc/examples/pendulum/sac.rst
@@ -1,0 +1,25 @@
+Pendulum with SAC
+==================
+
+In this notebook we solve the `Pendulum <https://gym.openai.com/envs/Pendulum-v0/>`_ environment
+using :doc:`SAC </examples/stubs/sac>`. We'll use a simple multi-layer percentron for our function
+approximator for the policy and q-function.
+
+This notebook periodically generates GIFs, so that we can inspect how the training is progressing.
+
+After a few hundred episodes, this is what you can expect:
+
+.. image:: /_static/img/pendulum.gif
+    :alt: Successfully swinging up the pendulum.
+    :width: 360px
+    :align: center
+
+----
+
+:download:`sac.py`
+
+.. image:: https://colab.research.google.com/assets/colab-badge.svg
+    :alt: Open in Google Colab
+    :target: https://colab.research.google.com/github/coax-dev/coax/blob/main/doc/_notebooks/pendulum/sac.ipynb
+
+.. literalinclude:: sac.py

--- a/doc/examples/pendulum/td3.rst
+++ b/doc/examples/pendulum/td3.rst
@@ -1,4 +1,4 @@
-Pendulum with DDPG
+Pendulum with TD3
 ==================
 
 In this notebook we solve the `Pendulum <https://gym.openai.com/envs/Pendulum-v0/>`_ environment


### PR DESCRIPTION
Since SAC is really similar to TD3, we are able to re-use most of its components. The differences are:

- The actions to update the q-functions and policy are sampled using the current policy (instead of taking the mode).
- There is no target policy.
- The log variance of the policy depends on the state.
- The policy is entropy regularized.

The current implementation does not support multi-step td-learning.