### PR TITLE
use list for simple replay buffer

### DIFF
--- a/coax/_core/stochastic_q_test.py
+++ b/coax/_core/stochastic_q_test.py
@@ -90,7 +90,7 @@ def func_quantile_type2(S, is_training):
         hk.Reshape((discrete.n, num_bins))
     ))(quantile_x)
     return {'values': quantile_values,
-            'quantile_fractions': quantile_fractions[:, None, :].tile([1, discrete.n, 1])}
+            'quantile_fractions': jnp.tile(quantile_fractions[:, None, :], [1, discrete.n, 1])}
 
 
 class TestStochasticQ(TestCase):

--- a/coax/experience_replay/_simple.py
+++ b/coax/experience_replay/_simple.py
@@ -58,6 +58,8 @@ class SimpleReplayBuffer(BaseReplayBuffer):
         transition_batch.idx = onp.arange(self._index, self._index + transition_batch.batch_size)
         self._index += transition_batch.batch_size
         self._storage.extend(transition_batch.to_singles())
+        while len(self) > self.capacity:
+            self._storage.pop(0)
 
     def sample(self, batch_size=32):
         r"""
@@ -84,7 +86,7 @@ class SimpleReplayBuffer(BaseReplayBuffer):
 
     def clear(self):
         r""" Clear the experience replay buffer. """
-        self._storage = deque(maxlen=self.capacity)
+        self._storage = list()
         self._index = 0
 
     def __len__(self):


### PR DESCRIPTION
When using the `SimpleReplayBuffer`, the sampling performance depends on the number of samples due to `deque`. This is caused by the slow indexed access to elements in the middle of the collection.

The simple switch to a `list` improves the performance significantly. An example for SAC on the Walker stand task from the [DeepMind Control Suite](https://github.com/deepmind/dm_control/) with a buffer size of 1M is given below.
    
![step time](https://user-images.githubusercontent.com/4137975/188002588-edf0e103-81cb-4dda-aa74-168a1662486e.png)

![return](https://user-images.githubusercontent.com/4137975/188002766-4fd70af5-bbae-4603-ae3d-d673aa44a1b7.png)

