### PR TITLE
Changed assertion in generate_gif to check on returned datatype

### DIFF
--- a/coax/utils/_misc.py
+++ b/coax/utils/_misc.py
@@ -472,11 +472,13 @@ def generate_gif(env, filepath, policy=None, resize_to=None, duration=50, max_ep
     if isinstance(env, TrainMonitor):
         env = env.env  # unwrap to strip off TrainMonitor
 
-    assert env.render_mode == 'rgb_array', "env.render_mode must be 'rgb_array'"
+    s, info = env.reset()
+
+    # check if render_mode is set to 'rbg_array'
+    assert isinstance(env.render(), onp.ndarray), "env.render_mode must be set to 'rgb_array'"
 
     # collect frames
     frames = []
-    s, info = env.reset()
     for t in range(max_episode_steps):
         a = env.action_space.sample() if policy is None else policy(s)
         s_next, r, done, truncated, info = env.step(a)

--- a/coax/utils/_misc.py
+++ b/coax/utils/_misc.py
@@ -475,7 +475,8 @@ def generate_gif(env, filepath, policy=None, resize_to=None, duration=50, max_ep
     s, info = env.reset()
 
     # check if render_mode is set to 'rbg_array'
-    assert isinstance(env.render(), onp.ndarray), "env.render_mode must be set to 'rgb_array'"
+    if not (env.render_mode == 'rgb_array' or isinstance(env.render(), onp.ndarray)):
+        raise RuntimeError("Cannot generate GIF if env.render_mode != 'rgb_array'.")
 
     # collect frames
     frames = []


### PR DESCRIPTION
G'day guys,
I have just stumbled across coax today and wanted to run the examples. However, an assert statement in the generate_gif function was unable to pass (see #37). The problem could be isolated to only Atari environments, which do return None for the render_mode. Perhaps due to this change: https://github.com/openai/gym/blob/6a04d49722724677610e36c1f92908e72f51da0c/gym/envs/registration.py#L631 where the internal representation is automatically set to None if it does only work with the compatibility layer.

I changed the assertion to work onto the datatype which should always be an `np.ndarray` for the `env.render_mode = 'rgb_array'`, and also differentiates from `env.render_mode = 'rgb_array_list'` which returns a `list[np.ndarray]`.

<img width="1510" alt="image" src="https://user-images.githubusercontent.com/38283585/209148031-8231ed22-28a5-4e4c-a81d-5b9aa6f4e63b.png">

This is only a minor problem but could solve some issues for people who want to try out the package and try the notebooks first.

Hope this helps.
– Ben

Edit: This is the link to the test notebook: https://github.com/benjaminbeilharz/coax/blob/main/doc/_notebooks/atari/dqn.ipynb